### PR TITLE
Fix pagination

### DIFF
--- a/src/EventApi.php
+++ b/src/EventApi.php
@@ -103,7 +103,7 @@ class EventApi implements EventApiInterface
             $current = $query;
 
             if (null !== $nextPageToken) {
-                $current['nextPageToken'] = $nextPageToken;
+                $current['pageToken'] = $nextPageToken;
             }
 
             $response = $this->guzzle->get(sprintf('calendars/%s/events', $this->calendar->getId()), ['query' => $current]);

--- a/src/EventApi.php
+++ b/src/EventApi.php
@@ -77,10 +77,6 @@ class EventApi implements EventApiInterface
         $query         = new Collection([]);
         $list          = new ArrayCollection;
 
-        if (null !== $this->calendar->getSyncToken()) {
-            $query->addCriterion(new Collection([new Field($this->calendar->getSyncToken())], 'nextSyncToken'));
-        }
-
         $fields = [new Field('nextSyncToken'),
                    new Field('nextPageToken'),
                    new Field('items', $this->fields)];


### PR DESCRIPTION
The pagination request is wrong, as it adds to the query params `nextPageToken` instead of `pageToken`. So, basically, it never fetches past page 2...

I also removed the automatic add of the `nextSyncToken` arg (which should be `syncToken`), because it has some specificities that are too bothersome to work with [[1]](https://developers.google.com/google-apps/calendar/v3/reference/events/list#syncToken)
