### PR TITLE
Composer changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,12 @@
 
     "require": {
         "php": ">=5.4.0",
+        
+        "calendart/calendart": "^1.6",
 
-        "psr/log": "~1.0",
-        "doctrine/collections": "~1.0",
-        "guzzlehttp/guzzle": "~4.1"
-    },
-
-    "require-dev": {
-        "calendart/calendart": "dev-master"
+        "psr/log": "^1.0",
+        "doctrine/collections": "^1.0",
+        "guzzlehttp/guzzle": "^4.1"
     },
 
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,6 @@
         "psr-4": {
             "CalendArt\\Adapter\\Google\\": ["src/", "test/"]
         }
-    },
-
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    }
 }
 


### PR DESCRIPTION
As it was noted in CalendArt/Office365Adapter#27, we should have `calendart/calendart` into the `require` rather than `require-dev`.

I also took the liberty to remove some configuration, it should not be up to calendart to take care of these things