### PR TITLE
Allow Guzzle 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 
         "psr/log": "^1.0",
         "doctrine/collections": "^1.0",
-        "guzzlehttp/guzzle": "^4.1"
+        "guzzlehttp/guzzle": "^4.1|^5.0"
     },
 
     "autoload": {


### PR DESCRIPTION
Adding Guzzle 5 to composer.json because google/google-api-php-client uses Guzzle 5.2 and up, and I want to use their library alongside this one.

PHPUnit passed with Guzzle 5, unfortunately not Guzzle 6, otherwise I'd added that one too.