### PR TITLE
Use php-http instead of guzzle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-    - 5.4
     - 5.5
     - 5.6
     - 7.0

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
 
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.5.0",
 
         "calendart/calendart": "^1.6",
 

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,23 @@
 
     "require": {
         "php": ">=5.4.0",
-        
+
         "calendart/calendart": "^1.6",
 
         "psr/log": "^1.0",
         "doctrine/collections": "^1.0",
-        "guzzlehttp/guzzle": "^4.1|^5.0"
+
+        "php-http/client-implementation": "^1.0",
+
+        "php-http/httplug": "^1.1",
+        "php-http/message": "^1.1",
+        "php-http/message-factory": "^1.0",
+        "php-http/client-common": "^1.4",
+        "php-http/discovery": "^1.1"
+    },
+
+    "require-dev": {
+        "php-http/guzzle6-adapter": "^1.1"
     },
 
     "autoload": {

--- a/src/Exception/ApiErrorException.php
+++ b/src/Exception/ApiErrorException.php
@@ -13,8 +13,7 @@ namespace CalendArt\Adapter\Google\Exception;
 
 use ErrorException;
 
-use GuzzleHttp\Message\ResponseInterface;
-use GuzzleHttp\Exception\ParseException;
+use Psr\Http\Message\ResponseInterface;
 
 use CalendArt\Exception\ApiErrorInterface;
 
@@ -29,12 +28,8 @@ abstract class ApiErrorException extends ErrorException implements ApiErrorInter
 
     public function __construct(ResponseInterface $response)
     {
-        try {
-            $this->details = $response->json();
-            $message = isset($this->details['error']['message']) ? $this->details['error']['message'] : $response->getReasonPhrase();
-        } catch (ParseException $e) {
-            $message = $response->getReasonPhrase();
-        }
+        $this->details = json_decode($response->getBody(), true);
+        $message = isset($this->details['error']['message']) ? $this->details['error']['message'] : $response->getReasonPhrase();
 
         parent::__construct(sprintf('The request failed and returned an invalid status code ("%d") : %s', $response->getStatusCode(), $message), $response->getStatusCode());
     }

--- a/src/ResponseHandler.php
+++ b/src/ResponseHandler.php
@@ -2,7 +2,7 @@
 
 namespace CalendArt\Adapter\Google;
 
-use GuzzleHttp\Message\ResponseInterface;
+use Psr\Http\Message\ResponseInterface;
 
 trait ResponseHandler
 {

--- a/test/Exception/ApiErrorExceptionTest.php
+++ b/test/Exception/ApiErrorExceptionTest.php
@@ -2,29 +2,16 @@
 
 namespace CalendArt\Adapter\Google;
 
-use GuzzleHttp\Message\ResponseInterface;
-use GuzzleHttp\Exception\ParseException;
+use Psr\Http\Message\ResponseInterface;
 
 use CalendArt\Adapter\Google\Exception\BadRequestException;
 
 class ApiErrorExceptionTest extends \PHPUnit_Framework_TestCase
 {
-    public function testConstructWithParseException()
-    {
-        $response = $this->prophesize('GuzzleHttp\Message\ResponseInterface');
-        $response->json()->shouldBeCalled()->willThrow(new ParseException);
-        $response->getStatusCode()->shouldBeCalled()->willReturn(400);
-        $response->getReasonPhrase()->shouldBeCalled()->willReturn('Invalid Argument');
-
-        $e = new BadRequestException($response->reveal());
-
-        $this->assertEquals('The request failed and returned an invalid status code ("400") : Invalid Argument', $e->getMessage());
-    }
-
     public function testConstructWithUnexceptedFormat()
     {
-        $response = $this->prophesize('GuzzleHttp\Message\ResponseInterface');
-        $response->json()->shouldBeCalled()->willReturn(['error' => []]);
+        $response = $this->prophesize(ResponseInterface::class);
+        $response->getBody()->shouldBeCalled()->willReturn('bad format');
         $response->getStatusCode()->shouldBeCalled()->willReturn(400);
         $response->getReasonPhrase()->shouldBeCalled()->willReturn('Invalid Argument');
 
@@ -35,8 +22,8 @@ class ApiErrorExceptionTest extends \PHPUnit_Framework_TestCase
 
     public function testConstructWithExceptedFormat()
     {
-        $response = $this->prophesize('GuzzleHttp\Message\ResponseInterface');
-        $response->json()->shouldBeCalled()->willReturn(['error' => ['message' => 'Api Message']]);
+        $response = $this->prophesize(ResponseInterface::class);
+        $response->getBody()->shouldBeCalled()->willReturn(json_encode(['error' => ['message' => 'Api Message']]));
         $response->getStatusCode()->shouldBeCalled()->willReturn(400);
         $response->getReasonPhrase()->shouldNotBeCalled();
 

--- a/test/ResponseHandlerTest.php
+++ b/test/ResponseHandlerTest.php
@@ -2,7 +2,7 @@
 
 namespace CalendArt\Adapter\Google;
 
-use GuzzleHttp\Message\ResponseInterface;
+use Psr\Http\Message\ResponseInterface;
 
 class ResponseHandlerTest extends \PHPUnit_Framework_TestCase
 {
@@ -11,16 +11,13 @@ class ResponseHandlerTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->response = $this->prophesize('GuzzleHttp\Message\ResponseInterface');
+        $this->response = $this->prophesize(ResponseInterface::class);
         $this->api = new Api;
     }
 
     public function testHandleErrorsWithSuccessfulResponse()
     {
         $this->response->getStatusCode()->shouldBeCalled()->willReturn(200);
-        $this->api->get($this->response->reveal());
-
-        $this->response->getStatusCode()->shouldBeCalled()->willReturn(301);
         $this->api->get($this->response->reveal());
     }
 
@@ -32,7 +29,7 @@ class ResponseHandlerTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException($exception);
 
         $this->response->getStatusCode()->shouldBeCalled()->willReturn($statusCode);
-        $this->response->json()->shouldBeCalled()->willReturn(['error' => ['message' => 'foo']]);
+        $this->response->getBody()->shouldBeCalled()->willReturn(json_encode(['error' => ['message' => 'foo']]));
         $this->response->getReasonPhrase()->willReturn($reasonPhrase);
         $this->api->get($this->response->reveal());
     }


### PR DESCRIPTION
fix #18 

Remove `guzzle` dependency and replace it by `php-http`.
I removed the usage of the http client from `CalendarApi` and `EventApi` to group all the requests into `GoogleAdapter`.

I have also updated de minimal requirement for php.

The base branch is now `2.0` 