### PR TITLE
introduce event organizer

### DIFF
--- a/src/Event/BasicEvent.php
+++ b/src/Event/BasicEvent.php
@@ -51,6 +51,9 @@ class BasicEvent extends AbstractEvent
     /** @var string Event's visibility */
     private $visibility = self::VISIBILITY_DEFAULT;
 
+    /** @var User organizer of this event */
+    protected $organizer;
+
     /** @return Datetime */
     public function getCreatedAt()
     {
@@ -160,6 +163,11 @@ class BasicEvent extends AbstractEvent
             $event->description = $data['description'];
         }
 
+        if (isset($data['organizer'])) {
+            $organizer = static::buildUser($data['organizer'])->addEvent($event);
+            $event->organizer = $organizer;
+        }
+
         if (isset($data['attendees'])) {
             $event->participations = static::buildParticipations($event, $data['attendees']);
         }
@@ -196,6 +204,7 @@ class BasicEvent extends AbstractEvent
 
             if (isset($attendee['organizer']) && true === $attendee['organizer']) {
                 $role |= EventParticipation::ROLE_MANAGER;
+                $this->organizer = $user;
             }
 
             $participation = new EventParticipation($event, $user, $role, EventParticipation::translateStatus($attendee['responseStatus']));
@@ -237,6 +246,11 @@ class BasicEvent extends AbstractEvent
         }
 
         return static::$users[$id];
+    }
+
+    public function getOrganizer()
+    {
+        return $this->organizer;
     }
 }
 


### PR DESCRIPTION
Google has a notion of `organizer` into its events.


> organizer	object	The organizer of the event. If the organizer is also an attendee, this is indicated with a separate entry in attendees with the organizer field set to True. To change the organizer, use the move operation. Read-only, except when importing an event.

https://developers.google.com/google-apps/calendar/v3/reference/events

Since the `organizer` is not always present into the attendees array., giving a way to retrieve it in the same principle as `owner` is useful.